### PR TITLE
fix: Raise exception on Turnstile verification failure to prevent pro…

### DIFF
--- a/cursor_pro_keep_alive.py
+++ b/cursor_pro_keep_alive.py
@@ -35,22 +35,20 @@ def handle_turnstile(tab):
                     time.sleep(random.uniform(1, 3))
                     challengeCheck.click()
                     time.sleep(2)
-                    logging.info("Turnstile 验证通过")
-                    return True
+                if tab.ele("@name=password"):
+                  logging.info("验证成功 - 已到达密码输入页面")
+                  break
+                if tab.ele("@data-index=0"):
+                  logging.info("验证成功 - 已到达验证码输入页面")
+                  break
+                if tab.ele("Account Settings"):
+                  logging.info("验证成功 - 已到达账户设置页面")
+                  break           
+                raise Exception("Turnstile 验证失败: 用户验证未通过")
             except:
                 pass
-
-            if tab.ele("@name=password"):
-                logging.info("验证成功 - 已到达密码输入页面")
-                break
-            if tab.ele("@data-index=0"):
-                logging.info("验证成功 - 已到达验证码输入页面")
-                break
-            if tab.ele("Account Settings"):
-                logging.info("验证成功 - 已到达账户设置页面")
-                break
-
-            time.sleep(random.uniform(1, 2))
+            logging.error(f"Turnstile 验证失败: Can’t verify the user is human")
+            return False
     except Exception as e:
         logging.error(f"Turnstile 验证失败: {str(e)}")
         return False


### PR DESCRIPTION
WIP
[#134 卡在Turnstile验证不动](https://github.com/chengazhen/cursor-auto-free/issues/134)
導致原因實際是驗證失敗後進行了下一步填寫密碼，因為找不到密碼輸入框直接進行Turnstile验证導致死循環一直卡在Turnstile验证不动
![CleanShot 2025-02-02 at 03 43 17@2x](https://github.com/user-attachments/assets/ef40d5b5-ac44-4b38-bf6f-29ab7ba78c0d)
![CleanShot 2025-02-02 at 03 44 29@2x](https://github.com/user-attachments/assets/607113c0-4322-4fd3-b162-46a2c58c5db7)
