### PR TITLE
update build.py as to use env prioritized

### DIFF
--- a/build.py
+++ b/build.py
@@ -162,13 +162,12 @@ def build():
         else:
             subprocess.run(["cp", "config.ini.example", f"{output_dir}/config.ini"])
 
-    # Copy .env.example file
-    if os.path.exists(".env.example"):
-        simulate_progress("Copying environment file...", 0.5)
-        if system == "windows":
-            subprocess.run(["copy", ".env.example", f"{output_dir}\\.env"], shell=True)
-        else:
-            subprocess.run(["cp", ".env.example", f"{output_dir}/.env"])
+    # Copy .env file or .env.example if .env doesn't exist
+    env_file = ".env" if os.path.exists(".env") else ".env.example"
+    if os.path.exists(env_file):
+        simulate_progress(f"Copying {'example ' if env_file == '.env.example' else ''}environment file...", 0.5)
+        copy_command = "copy" if system == "windows" else "cp"
+        subprocess.run([copy_command, env_file, f"{output_dir}/.env"], shell=(system == "windows"))
 
     print(
         f"\n\033[92mBuild completed successfully! Output directory: {output_dir}\033[0m"


### PR DESCRIPTION
Developers would prefer to build the src locally thus taking their own `.env` (if not exists then use env.example) to build the final `CursorPro` executable. Do you like it @chengazhen ?