### PR TITLE
fix: 修复Windows下Cursor路径获取逻辑

### DIFF
--- a/patch_cursor_get_machine_id.py
+++ b/patch_cursor_get_machine_id.py
@@ -49,7 +49,7 @@ def get_cursor_paths() -> Tuple[str, str]:
         },
         "Windows": {
             "base": os.path.join(
-                os.getenv("LOCALAPPDATA", ""), "Programs", "Cursor", "resources", "app"
+                os.getenv("USERAPPPATH") or (os.getenv("LOCALAPPDATA", ""), "Programs", "Cursor", "resources", "app")
             ),
             "package": "package.json",
             "main": "out/main.js",


### PR DESCRIPTION
修复自定义cursor安装路径时错误，添加env获取