### PR TITLE
fix: 修复了在 get_cursor_paths 函数中构建 base 路径时传参的类型错误

### DIFF
--- a/patch_cursor_get_machine_id.py
+++ b/patch_cursor_get_machine_id.py
@@ -49,7 +49,7 @@ def get_cursor_paths() -> Tuple[str, str]:
         },
         "Windows": {
             "base": os.path.join(
-                os.getenv("USERAPPPATH") or (os.getenv("LOCALAPPDATA", ""), "Programs", "Cursor", "resources", "app")
+                os.getenv("USERAPPPATH") or os.path.join(os.getenv("LOCALAPPDATA", ""), "Programs", "Cursor", "resources", "app")
             ),
             "package": "package.json",
             "main": "out/main.js",


### PR DESCRIPTION
os.getenv("LOCALAPPDATA", "")需要一个字符串，而(os.getenv("LOCALAPPDATA", ""), "Programs", "Cursor", "resources", "app")返回了一个元组，故改为使用 os.path.join 连接字符串