### PR TITLE
fix: 默认使用 POP3 协议，与端口 993 协议冲突

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ IMAP_PORT=993               # 993
 IMAP_USER=xxxx@xxxx.com    # 接收邮箱地址
 IMAP_PASS=xxxxxxxxxxxxx    # 邮箱授权码
 # IMAP_DIR=                  # [可选] 默认为收件箱(inbox)
-IMAP_PROTOCOL=POP3     # 指定使用 POP3 协议
+IMAP_PROTOCOL=IMAP     # 指定使用 IMAP 协议
 
 BROWSER_USER_AGENT=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.92 Safari/537.36
 


### PR DESCRIPTION
将默认协议修改为 IMAP 与端口 993 相匹配