### PR TITLE
 Add -k flag to bypass SSL certificate verification for macOS curl command

### DIFF
--- a/go_cursor_help.py
+++ b/go_cursor_help.py
@@ -10,7 +10,8 @@ def go_cursor_help():
     base_url = "https://aizaozao.com/accelerate.php/https://raw.githubusercontent.com/yuaotian/go-cursor-help/refs/heads/master/scripts/run"
     
     if system == "Darwin":  # macOS
-        cmd = f'curl -k -fsSL {base_url}/cursor_mac_id_modifier.sh | sudo bash'        logging.info("执行macOS命令")
+        cmd = f'curl -k -fsSL {base_url}/cursor_mac_id_modifier.sh | sudo bash'
+        logging.info("执行macOS命令")
         os.system(cmd)
     elif system == "Linux":
         cmd = f'curl -fsSL {base_url}/cursor_linux_id_modifier.sh | sudo bash'

--- a/go_cursor_help.py
+++ b/go_cursor_help.py
@@ -10,8 +10,7 @@ def go_cursor_help():
     base_url = "https://aizaozao.com/accelerate.php/https://raw.githubusercontent.com/yuaotian/go-cursor-help/refs/heads/master/scripts/run"
     
     if system == "Darwin":  # macOS
-        cmd = f'curl -fsSL {base_url}/cursor_mac_id_modifier.sh | sudo bash'
-        logging.info("执行macOS命令")
+        cmd = f'curl -k -fsSL {base_url}/cursor_mac_id_modifier.sh | sudo bash'        logging.info("执行macOS命令")
         os.system(cmd)
     elif system == "Linux":
         cmd = f'curl -fsSL {base_url}/cursor_linux_id_modifier.sh | sudo bash'
@@ -27,3 +26,9 @@ def go_cursor_help():
         return False
     
     return True
+
+def main():
+    go_cursor_help()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
fix: Add -k flag to bypass SSL certificate verification for macOS curl command

## What's Changed
- Added `-k` flag to curl command for macOS to bypass SSL certificate verification
- This fixes the error: "SSL: no alternative certificate subject name matches target host name 'aizaozao.com'"

## Why
The target host (aizaozao.com) is using a certificate with CN=144.48.212.178 that doesn't include aizaozao.com in its Subject Alternative Names (SAN), causing SSL verification to fail.

## Security Note
While this is a temporary fix to keep the functionality working, it bypasses SSL certificate validation. A proper fix would be to update the server's SSL certificate to include the correct domain name.

## Testing
1. Run the script on macOS
2. Verify that the curl command executes without SSL errors
3. Confirm the script completes its intended functionality

Related error:
```curl: (60) SSL: no alternative certificate subject name matches target host name 'aizaozao.com'```