### PR TITLE
fix: Avoid misidentifying 6-digit domain names as verification codes

### DIFF
--- a/get_email_code.py
+++ b/get_email_code.py
@@ -106,6 +106,8 @@ class EmailVerificationHandler:
                     continue
                 body = self._extract_imap_body(email_message)
                 if body:
+                    # 避免 6 位数字的域名被误识别成验证码
+                    body = body.replace(self.account, '')
                     code_match = re.search(r"\b\d{6}\b", body)
                     if code_match:
                         code = code_match.group()


### PR DESCRIPTION
修复：避免将 6 位数字域名误识别为验证码

close #244 
close #319 